### PR TITLE
use 3.1.6-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.7-bullseye
+FROM ruby:3.1.6-bookworm
 LABEL maintainer "gavin zhou <gavin.zhou@gmail.com>"
 
 # gpg keys listed at https://github.com/nodejs/node#release-keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.6-buster
+FROM ruby:3.0.7-bullseye
 LABEL maintainer "gavin zhou <gavin.zhou@gmail.com>"
 
 # gpg keys listed at https://github.com/nodejs/node#release-keys


### PR DESCRIPTION
ベースイメージを3.1.6-bookwormに変更します。
付与予定のタグは palettecloud/ruby-node:v3.1.6-12.13.0